### PR TITLE
change isPlaying state to false when stop func gets called

### DIFF
--- a/Sources/Subsonic/SubsonicPlayer.swift
+++ b/Sources/Subsonic/SubsonicPlayer.swift
@@ -77,6 +77,7 @@ public class SubsonicPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
 
     /// Stops the audio from playing.
     public func stop() {
+        isPlaying = false
         audioPlayer?.stop()
     }
 


### PR DESCRIPTION
Calling a stop() on SubsonicPlayer instance doesn't trigger audioPlayerDidFinishPlaying so the isPlaying state doesn't change back to false. My fix is to toggle isPlaying inside the stop() func body.